### PR TITLE
fixed timeout handler to correctly log 500 errors

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <libavformat/avformat.h>
+#define SDL_MAIN_HANDLED // avoid link error on Linux Windows Subsystem
 #include <SDL2/SDL.h>
 
 #include "compat.h"


### PR DESCRIPTION
Build failed on WSL because of lack of reference to WinMain@16 during
linking.

Fixes <https://github.com/Genymobile/scrcpy/issues/316>

Signed-off-by: Romain Vimont <rom@rom1v.com>