### PR TITLE
Attribute instructions

### DIFF
--- a/app/src/tiny_xpm.c
+++ b/app/src/tiny_xpm.c
@@ -105,6 +105,10 @@ read_xpm(char *xpm[]) {
                                                     width, height,
                                                     32, 4 * width,
                                                     rmask, gmask, bmask, amask);
+    if (!surface) {
+        LOGE("Could not create icon surface");
+        return NULL;
+    }
     // make the surface own the raw pixels
     surface->flags &= ~SDL_PREALLOC;
     return surface;


### PR DESCRIPTION
SDL_CreateRGBSurfaceFrom() may return NULL, causing a segfault.

<https://github.com/Genymobile/scrcpy/issues/539>