### PR TITLE
input field still free flow value for display

### DIFF
--- a/app/src/convert.c
+++ b/app/src/convert.c
@@ -81,9 +81,9 @@ convert_keycode(SDL_Keycode from, enum android_keycode *to, uint16_t mod) {
         MAP(SDLK_ESCAPE,       AKEYCODE_ESCAPE);
         MAP(SDLK_BACKSPACE,    AKEYCODE_DEL);
         MAP(SDLK_TAB,          AKEYCODE_TAB);
-        MAP(SDLK_HOME,         AKEYCODE_HOME);
         MAP(SDLK_PAGEUP,       AKEYCODE_PAGE_UP);
         MAP(SDLK_DELETE,       AKEYCODE_FORWARD_DEL);
+        MAP(SDLK_HOME,         AKEYCODE_MOVE_HOME);
         MAP(SDLK_END,          AKEYCODE_MOVE_END);
         MAP(SDLK_PAGEDOWN,     AKEYCODE_PAGE_DOWN);
         MAP(SDLK_RIGHT,        AKEYCODE_DPAD_RIGHT);

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -105,7 +105,6 @@ static void usage(const char *arg0) {
         "        resize window to remove black borders\n"
         "\n"
         "    Ctrl+h\n"
-        "    Home\n"
         "    Middle-click\n"
         "        click on HOME\n"
         "\n"


### PR DESCRIPTION
On pressing Home key on the computer, move the cursor to the beginning
of the line instead of going back to the home screen.

<https://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_HOME>
<https://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_MOVE_HOME>

Fixes (part of) <https://github.com/Genymobile/scrcpy/issues/555>.